### PR TITLE
Fixed errors caused by $raw variable not being available.

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -109,7 +109,7 @@ class CWS_Slug_Control_Plugin extends WP_Stack_Plugin2 {
 	 */
 	public function sanitize_title( $title, $raw_title, $context ) {
 		if ( 'display' === $context || 'save' === $context ) {
-			$title = apply_filters( 'cws_tc_sanitize_title', $title, $raw, $context );
+			$title = apply_filters( 'cws_tc_sanitize_title', $title, $raw_title, $context );
 		}
 		return $title;
 	}


### PR DESCRIPTION
In the sanitize_title method of the CWS_Slug_Control_Plugin class the filter attempts to use the variable $raw instead of $raw_title resulting in numerous PHP notices [( ! ) Notice: Undefined variable: raw in .../slug-control/classes/plugin.php on line 112] throughout the Dashboard. This fixes the notices by simply correcting the typo.
